### PR TITLE
FEAT - allow setting of custom csv engine via context

### DIFF
--- a/lib/csvbuilder/importer/internal/import/csv.rb
+++ b/lib/csvbuilder/importer/internal/import/csv.rb
@@ -15,7 +15,8 @@ module Csvbuilder
 
       validate { begin; _ruby_csv; rescue StandardError => e; errors.add(:csv, e.message) end }
 
-      def initialize(file_path)
+      def initialize(file_path, custom_csv_engine = nil)
+        @custom_csv_engine = custom_csv_engine
         @file_path = file_path
         reset
       end
@@ -82,7 +83,9 @@ module Csvbuilder
       protected
 
       def _ruby_csv
-        CSV.open(file_path)
+        csv_engine = @custom_csv_engine || CSV
+
+        csv_engine.open(file_path)
       end
 
       def _read_row

--- a/lib/csvbuilder/importer/public/import/file.rb
+++ b/lib/csvbuilder/importer/public/import/file.rb
@@ -22,10 +22,11 @@ module Csvbuilder
       # @param [String] file_path path of csv file
       # @param [Import] row_model_class model class returned for importing
       # @param context [Hash] context passed to the {Import}
+      # @opt [CSV] custom_csv_engine custom implementation of CSV class
       def initialize(file_path, row_model_class, context = {})
-        @csv             = ::Csvbuilder::Import::Csv.new(file_path) # Full namespace provided to avoid confusion with Ruby CSV class.
-        @row_model_class = row_model_class
         @context         = context.to_h.symbolize_keys
+        @row_model_class = row_model_class
+        @csv             = ::Csvbuilder::Import::Csv.new(file_path, context[:custom_csv_engine]) # Full namespace provided to avoid confusion with Ruby CSV class.
         reset
       end
 


### PR DESCRIPTION
This PR allows for the passing of a Custom CSV class (aka a CSV Engine) to replace the custom ruby stdlib `CSV` class. The initial reason for requiring this feature is that so we can pass a custom CSV Engine which extends the stdlib version to do some pre-processing of the csv object. In our case that is handling issues relating to `byte_order_prefixes`. 

I have made the custom CSV Engine an option via the `context` hash as I wanted to avoid breaking existing code which expects the positional arguments in a certain order. I also thought using a keyword arguments might be a bit confusing on top of having a context hash.  