### PR TITLE
Using Less Memory And Quicker Line Counter

### DIFF
--- a/lib/csvbuilder/importer/internal/import/csv.rb
+++ b/lib/csvbuilder/importer/internal/import/csv.rb
@@ -20,10 +20,10 @@ module Csvbuilder
         reset
       end
 
-      # http://stackoverflow.com/questions/2650517/count-the-number-of-lines-in-a-file-without-reading-entire-file-into-memory
+      # https://gist.github.com/guilhermesimoes/d69e547884e556c3dc95?permalink_comment_id=4502636#gistcomment-4502636
       # @return [Integer] the number of rows in the file, including empty new lines
       def size
-        @size ||= ::File.readlines(file_path).length
+        @size ||= ::File.read(file_path).count($/)
       end
 
       # If the current position is at the headers, skip it and return it. Otherwise, only return false.


### PR DESCRIPTION
Using less memory and quicker.

Performance

```
Results

Warming up --------------------------------------
                size    31.000  i/100ms
              length    75.000  i/100ms
               count    77.000  i/100ms
   each_line + count    81.000  i/100ms
           count($/)   196.000  i/100ms
Calculating -------------------------------------
                size      1.529k (±33.9%) i/s -      4.774k in   5.015361s
              length      1.434k (±38.8%) i/s -      5.025k in   5.139834s
               count      1.335k (±40.7%) i/s -      4.697k in   5.079353s
   each_line + count      1.411k (±39.5%) i/s -      5.022k in   5.110146s
           count($/)      2.231k (± 2.6%) i/s -     11.172k in   5.012323s

Comparison:
           count($/):     2230.5 i/s
                size:     1529.0 i/s - 1.46x  (± 0.00) slower
              length:     1434.2 i/s - 1.56x  (± 0.00) slower
   each_line + count:     1411.0 i/s - 1.58x  (± 0.00) slower
               count:     1334.9 i/s - 1.67x  (± 0.00) slower
```

https://gist.github.com/guilhermesimoes/d69e547884e556c3dc95?permalink_comment_id=4502636#gistcomment-4502636
