### PR TITLE
Add Csvbuilder::Import::File#abort!

### DIFF
--- a/spec/csvbuilder/importer/public/import/file_spec.rb
+++ b/spec/csvbuilder/importer/public/import/file_spec.rb
@@ -117,8 +117,18 @@ module Csvbuilder
       describe "#each" do
         subject(:each_row) { instance.each }
 
-        context "with abort" do
+        context "with abort from row model" do
           before { allow(instance).to receive(:abort?).and_return(true) }
+
+          it "never yields and call callbacks" do
+            allow(instance).to receive(:run_callbacks).with(:abort).once
+
+            expect { each_row.next }.to raise_error(StopIteration)
+          end
+        end
+
+        context "with abort from file importer" do
+          before { instance.abort! }
 
           it "never yields and call callbacks" do
             allow(instance).to receive(:run_callbacks).with(:abort).once


### PR DESCRIPTION
## Aborting an import

There is a design challenge to handling an import line-by-line. If it makes the code more efficient and decoupled, we might have cases when we want to check something shared with all lines. The obvious ones are the headers. Let's say we want to check them and abort all imports if something wrong is detected. We probably don't want to add the abort conditioning on every line (Csvbuilder::Model or, more precisely, its extension Csvbuilder::Import). We would rather have it in the Importer itself. In that case, we can stop the Importer from invoking "abort!". Let's consider the following example:

```ruby
class Importer < Csvbuilder::Import::File

  after_next do
    if HeaderChecker.new(current_row_model).invalid?
      abort!
      next true # Keep going into #each and hit the callbacks
    end
  end

end
```

```ruby
context "with incorrect headers" do

  should "not import data" do
    importer = Importer.new(@file.path, @importer_class, @context)

    row_enumerator = importer.each

    assert_raises StopIteration do
      row_enumerator.next
    end
  end
end
```
